### PR TITLE
add image description to NoteAttachment

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -92,6 +92,7 @@ pub struct NoteAttachment {
     blurhash: Option<String>,
     width: Option<u64>,
     height: Option<u64>,
+    description: Option<String>,
 }
 
 #[allow(non_snake_case)]
@@ -2811,6 +2812,7 @@ pub fn ap_block_send_live_note(podcast_guid: u64, episode: &PILiveItem, inbox_ur
                     width: Some(640),
                     height: None,
                     value: None,
+                    description: Some("Show's artwork from the channel feed".to_string()),
                 }
             ),
         },
@@ -3061,6 +3063,7 @@ pub fn build_episode_note_object(
                 width: Some(640),
                 height: None,
                 value: None,
+                description: Some(format!("Episode artwork for {}", episode.title).to_string()),
             }
         ),
     });


### PR DESCRIPTION
Some Fediverse instances won't show the images of a toot/message if not ALT text is given.

I would rather have a more verbose description like:

>Artwork from the $episode, more info in $episode_web_URL

but given what I've seen already in the code this is what I can write (without been a developer)

Not tested, and first time reading rust code, so probably this would crash the server.
Let's call this an issue+ more than a real PR 